### PR TITLE
Automatic generation of Experimental Setup info

### DIFF
--- a/bench.sc
+++ b/bench.sc
@@ -57,10 +57,7 @@ def client(name: String, master: AddressArg, runid: String, publicif: String, cl
 		case Some(impl) => {
 			println(s"Found Benchmark ${impl.label} for ${name}. Master is at $master");
 			val logdir = logs / runId;
-			if (!exists(logdir)) {
-				mkdir! logdir;
-				%%.apply(root/'bin/'bash, "-c",s"./exp_setup.sh $logdir");
-			}
+			mkdir! logdir;
 			val clientRunner = impl.clientRunner(master, s"${publicIf}:${clientPort}");
 			val client = clientRunner.run(logdir);
 			Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -124,7 +121,7 @@ def remote(withNodes: Path = defaultNodesFile, testing: Boolean = false, impls: 
 @doc("Run benchmarks using a cluster of nodes.")
 @main
 def fakeRemote(withClients: Int = 1, testing: Boolean = false, impls: Seq[String] = Seq.empty, benchmarks: Seq[String] = Seq.empty, remoteDir: os.Path = tmp.dir()): Unit = {
-	val alwaysCopyFiles = List[Path](relp("bench.sc"), relp("benchmarks.sc"), relp("build.sc"), relp("client.sh"), relp("exp_setup.sh"));
+	val alwaysCopyFiles = List[Path](relp("bench.sc"), relp("benchmarks.sc"), relp("build.sc"), relp("client.sh"));
 	val masterBenches = runnersForImpl(impls, identity);
 	val (copyFiles: List[RelPath], copyDirectories: List[RelPath]) = masterBenches.map(_.mustCopy).flatten.distinct.partition(_.isFile) match {
 		case (files, folders) => ((files ++ alwaysCopyFiles).map(_.relativeTo(pwd)), folders.map(_.relativeTo(pwd)))

--- a/exp_setup.sh
+++ b/exp_setup.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
-file=$1/experimental_setup.out
-touch $file
-echo "System: $(eval "uname -a")" >> $file
-echo "Git: branch: $(eval "git rev-parse --abbrev-ref HEAD"), hash: $(eval "git rev-parse HEAD")" >> $file
-echo "Rust: $(eval "rustc --version")" >> $file
-echo "Java: $(eval "java --version")" >> $file
-echo "Erlang: $(eval "erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), \"releases\", erlang:system_info(otp_release), \"OTP_VERSION\"])), io:fwrite(Version), halt().' -noshell")" >> $file
+declare -a s=(
+	"System: $(uname -a)" 
+	"Git: branch: $(git rev-parse --abbrev-ref HEAD), commit: $(git rev-parse HEAD)"
+	"Rust: $(rustc --version)"
+	"Java: $(java --version)"
+	"Erlang: $(erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell)"
+)
+if [ -z "$1" ]
+  then
+    for val in "${s[@]}"; do
+  		echo $val
+	done
+else
+	file=$1/experimental_setup.out
+	touch $file
+    for val in "${s[@]}"; do
+  		echo $val >> $file
+	done
+fi

--- a/exp_setup.sh
+++ b/exp_setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+file=$1/experimental_setup.out
+touch $file
+echo "System: $(eval "uname -a")" >> $file
+echo "Git: branch: $(eval "git rev-parse --abbrev-ref HEAD"), hash: $(eval "git rev-parse HEAD")" >> $file
+echo "Rust: $(eval "rustc --version")" >> $file
+echo "Java: $(eval "java --version")" >> $file
+echo "Erlang: $(eval "erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), \"releases\", erlang:system_info(otp_release), \"OTP_VERSION\"])), io:fwrite(Version), halt().' -noshell")" >> $file


### PR DESCRIPTION
When running benchmarks without the `testing` flag, information about the experimental setup will be automatically generated in the results directory. This includes:

- System information
- Current git branch and latest commit id
- Rust version
- Java version
- Erlang version

(Could not find a smooth solution for Scala. However, it can be tracked looking at the corresponding sbt files of the git commit id)



